### PR TITLE
Add azimuth/coordinate conversion when saving tree

### DIFF
--- a/lib/views/widgets/manage_data_widget/dialog_add_tree_widget.dart
+++ b/lib/views/widgets/manage_data_widget/dialog_add_tree_widget.dart
@@ -3,6 +3,7 @@ import 'package:azimutree/data/models/cluster_model.dart';
 import 'package:azimutree/data/models/plot_model.dart';
 import 'package:azimutree/data/models/tree_model.dart';
 import 'package:azimutree/data/notifiers/tree_notifier.dart';
+import 'package:azimutree/services/azimuth_latlong_service.dart';
 
 enum TreePositionInputMode { azimuthDistance, coordinates }
 
@@ -138,6 +139,8 @@ class _DialogAddTreeWidgetState extends State<DialogAddTreeWidget> {
     }
 
     final selectedPlotId = _selectedPlotId!;
+    final selectedPlot =
+        plotsForSelectedCluster.firstWhere((plot) => plot.id == selectedPlotId);
 
     final kodePohonText = _kodePohonController.text.trim();
     final namaPohonText = _namaPohonController.text.trim();
@@ -166,13 +169,31 @@ class _DialogAddTreeWidgetState extends State<DialogAddTreeWidget> {
     if (_positionMode == TreePositionInputMode.azimuthDistance) {
       azimut = double.tryParse(_azimutController.text.trim());
       jarakPusatM = double.tryParse(_jarakPusatController.text.trim());
-      latitude = null;
-      longitude = null;
+      if (azimut == null || jarakPusatM == null) return;
+
+      final targetPoint = AzimuthLatLongService.fromAzimuthDistance(
+        centerLatDeg: selectedPlot.latitude,
+        centerLonDeg: selectedPlot.longitude,
+        azimuthDeg: azimut,
+        distanceM: jarakPusatM!,
+      );
+
+      latitude = targetPoint.latitude;
+      longitude = targetPoint.longitude;
     } else {
       latitude = double.tryParse(_latitudeController.text.trim());
       longitude = double.tryParse(_longitudeController.text.trim());
-      azimut = null;
-      jarakPusatM = null;
+      if (latitude == null || longitude == null) return;
+
+      final azimuthDistance = AzimuthLatLongService.toAzimuthDistance(
+        centerLatDeg: selectedPlot.latitude,
+        centerLonDeg: selectedPlot.longitude,
+        targetLatDeg: latitude!,
+        targetLonDeg: longitude!,
+      );
+
+      azimut = azimuthDistance.azimuthDeg;
+      jarakPusatM = azimuthDistance.distanceM;
     }
 
     final newTree = TreeModel(


### PR DESCRIPTION
## Summary
- integrate AzimuthLatLongService into the add tree dialog
- convert azimuth and distance entries to coordinates before saving
- derive azimuth and distance when coordinates are provided

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693127986080832fb24c8bb6f60963ef)